### PR TITLE
Removing logical expression from getData return

### DIFF
--- a/DragDropTouch.js
+++ b/DragDropTouch.js
@@ -85,7 +85,8 @@ let DragDropTouch;
             if (lcType === "text" && data == null) {
                 data = this._data["text/plain"]; // getData("text") also gets ("text/plain")
             }
-            return data || "";
+
+            return data;
         };
         /**
          * Set the data for a given type.


### PR DESCRIPTION
Not sure why we have this logical expression on the return, as we should want to receive exactly what data found, even falsy values.
As with the current logical expression, if the value found is falsy it will return an empty string, and that might break.

Real case example:
If you store an index 0 with the setData, when getting with getData you will actually receive an empty string and not 0. That doesn't happen with native DataTransfer event that returns correctly.

This is the motivation for this pull request. 

Still, if we do want to have some kind of validation, I'd suggest to check rather the value is Null or Undefined specifically, and only on those cases return an empty string.